### PR TITLE
Fix Internal Server Error on non-Windows systems

### DIFF
--- a/src/SIS.HTTP/Common/GlobalConstants.cs
+++ b/src/SIS.HTTP/Common/GlobalConstants.cs
@@ -5,5 +5,7 @@
         public const string HttpOneProtocolFragment = "HTTP/1.1";
 
         public const string HostHeaderKey = "Host";
+
+        public const string HttpNewLine = "\r\n";
     }
 }

--- a/src/SIS.HTTP/Headers/HttpHeaderCollection.cs
+++ b/src/SIS.HTTP/Headers/HttpHeaderCollection.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using SIS.HTTP.Common;
 
 namespace SIS.HTTP.Headers
 {
@@ -29,7 +29,7 @@ namespace SIS.HTTP.Headers
 
         public override string ToString()
         {
-            return string.Join(Environment.NewLine, this.headers.Values);
+            return string.Join(GlobalConstants.HttpNewLine, this.headers.Values);
         }
     }
 }

--- a/src/SIS.HTTP/Requests/HttpRequest.cs
+++ b/src/SIS.HTTP/Requests/HttpRequest.cs
@@ -178,7 +178,7 @@ namespace SIS.HTTP.Requests
         private void ParseRequest(string requestString)
         {
             string[] splitRequestContent = requestString
-                .Split(new[] {Environment.NewLine}, StringSplitOptions.None);
+                .Split(new[] {GlobalConstants.HttpNewLine}, StringSplitOptions.None);
 
             string[] requestLine = splitRequestContent[0].Trim().
                 Split(new [] {' '}, StringSplitOptions.RemoveEmptyEntries);

--- a/src/SIS.HTTP/Responses/HttpResponse.cs
+++ b/src/SIS.HTTP/Responses/HttpResponse.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Text;
 using SIS.HTTP.Common;
 using SIS.HTTP.Cookies;
@@ -49,15 +48,15 @@ namespace SIS.HTTP.Responses
             StringBuilder result = new StringBuilder();
 
             result
-                .Append($"{GlobalConstants.HttpOneProtocolFragment} {this.StatusCode.GetResponseLine()}").Append(Environment.NewLine)
-                .Append(this.Headers).Append(Environment.NewLine);
+                .Append($"{GlobalConstants.HttpOneProtocolFragment} {this.StatusCode.GetResponseLine()}").Append(GlobalConstants.HttpNewLine)
+                .Append(this.Headers).Append(GlobalConstants.HttpNewLine);
 
             if (this.Cookies.HasCookies())
             {
-                result.Append($"Set-Cookie: {this.Cookies}").Append(Environment.NewLine);
+                result.Append($"Set-Cookie: {this.Cookies}").Append(GlobalConstants.HttpNewLine);
             }
 
-            result.Append(Environment.NewLine);
+            result.Append(GlobalConstants.HttpNewLine);
 
             return result.ToString();
         }


### PR DESCRIPTION
According to [RFC2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.2) headers must always be separated with CR LF.

Currently the server cannot properly parse requests and create responses when running on a non-Windows host, because it uses Environment.NewLine, which returns "\r\n" on Windows and "\n" on Unix platforms. This results in an Internal Server Error.

The issue can be fixed by replacing Environment.NewLine with a constant with the value of "\r\n".