### PR TITLE
Remove duplicate HttpOnly flag on session cookies

### DIFF
--- a/src/SIS.WebServer/ConnectionHandler.cs
+++ b/src/SIS.WebServer/ConnectionHandler.cs
@@ -105,7 +105,7 @@ namespace SIS.WebServer
             {
                 httpResponse
                     .AddCookie(new HttpCookie(HttpSessionStorage.SessionCookieKey
-                        , $"{sessionId}; HttpOnly"));
+                        , sessionId));
             }
         }
 


### PR DESCRIPTION
Currently an HttpOnly flag is appended to the value of the session cookie in the ConnectionHandler. This flag, combined with the cookie's own HttpOnly flag, causes the response header to have two HttpOnly flags for the session cookie.
This can be fixed by removing the additional flag currently being concatenated to cookie's value when creating the cookie in the ConnectionHandler.