### PR TITLE
Fix path traversal vulnerability when serving resources

### DIFF
--- a/src/SIS.WebServer/ConnectionHandler.cs
+++ b/src/SIS.WebServer/ConnectionHandler.cs
@@ -113,7 +113,7 @@ namespace SIS.WebServer
         private bool IsResourceRequest(IHttpRequest httpRequest)
         {
             var requestPath = httpRequest.Path;
-            if (requestPath.Contains('.'))
+            if (requestPath.Contains('.') && !requestPath.Contains(".."))
             {
                 var requestPathExtension = requestPath
                     .Substring(requestPath.LastIndexOf('.'));


### PR DESCRIPTION
There is a path traversal vulnerability in the code responsible for serving files from the /Resources directory. Any file on the host's file system can be accessed remotely if its extension is in GlobalConstants.ResourceExtensions (currently only .js and .css files).
This can be fixed by blocking resource requests containing ".." in their path.

Here is a command that can be used to exploit the vulnerability:
```
$ echo -en 'GET /..\..\..\..\..\..\..\..\..\..\..\Users\SomeUser\RandomFile.js HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n' | nc 127.0.0.1 80

HTTP/1.1 200 OK
Content-Length: 23
Content-Disposition: inline
Set-Cookie: SIS_ID=5eb743e9-49b5-49ca-b495-5e2f2ea85708; Expires=Sun, 14 Oct 2018 14:31:54 GMT; HttpOnly; Path=/

some content
```
In this example, a file located in C:\Users\SomeUser\RandomFile.js with content "some content", which is outside of the /Resources directory and should not be accessible remotely, is read and returned by the web server.