### PR TITLE
Fixed authorization attribute.

### DIFF
--- a/src/SIS.MvcFramework/Routing/RoutingEngine.cs
+++ b/src/SIS.MvcFramework/Routing/RoutingEngine.cs
@@ -136,7 +136,7 @@ namespace SIS.MvcFramework.Routing
                             if (hasAuthorizeAttribute)
                             {
                                 var userData = Controller.GetUserData(request.Cookies, userCookieService);
-                                if (userData == null)
+                                if (userData.Username == null)
                                 {
                                     var response = new HttpResponse();
                                     response.Headers.Add(new HttpHeader(HttpHeader.Location, settings.LoginPageUrl));


### PR DESCRIPTION
Userdata property will never be null. Replaced it with Userdata.Username which can be null if the user isn't logged in.